### PR TITLE
Fix npm repo links

### DIFF
--- a/package.dist.json
+++ b/package.dist.json
@@ -11,11 +11,11 @@
     "typedoc-plugin"
   ],
   "bugs": {
-    "url": "https://github.com/matteobruni/typedoc-google-ads-plugin/issues"
+    "url": "https://github.com/matteobruni/typedoc-keyword-plugin/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/matteobruni/typedoc-google-ads-plugin.git"
+    "url": "git+https://github.com/matteobruni/typedoc-keyword-plugin.git"
   },
   "files": [
     "./**/*"


### PR DESCRIPTION
Fixes the links displayed at https://www.npmjs.com/package/typedoc-plugin-keyword to point to this repo